### PR TITLE
Add family to link messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ All returned tables have the following entries:
 
 #### Event "newlink" and "dellink"
 
+ - family: AF\_...
  - hwaddr: The MAC address
  - mtu: Maximum Transfer Unit
  - name: Interface name

--- a/src/ifaddr.c
+++ b/src/ifaddr.c
@@ -27,8 +27,7 @@ static int parse_attr(const struct nlattr *attr, void *data)
 static int ifaddr_cb(const struct nlmsghdr *nlh, struct callback_data *cbd)
 {
 	push_integer(cbd->L, "index", cbd->ifa->ifa_index);
-	push_string(cbd->L, "family", cbd->ifa->ifa_family == AF_INET ?
-					"AF_INET" : "AF_INET6");
+	push_string(cbd->L, "family", af_to_str(cbd->ifa->ifa_family));
 	push_integer(cbd->L, "prefixlen", cbd->ifa->ifa_prefixlen);
 	push_integer(cbd->L, "scope", cbd->ifa->ifa_scope);
 	push_integer(cbd->L, "flags", cbd->ifa->ifa_flags);

--- a/src/link.c
+++ b/src/link.c
@@ -39,6 +39,7 @@ static int parse_attr(const struct nlattr *attr, void *data)
 static int link_cb(const struct nlmsghdr *nlh, struct callback_data *cbd)
 {
 	push_integer(cbd->L, "index", cbd->ifm->ifi_index);
+	push_string(cbd->L, "family", af_to_str(cbd->ifm->ifi_family));
 	push_bool(cbd->L, "running", cbd->ifm->ifi_flags & IFF_RUNNING);
 	push_bool(cbd->L, "up", cbd->ifm->ifi_flags & IFF_UP);
 

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -25,6 +25,111 @@ struct userdata {
 	int groups;
 };
 
+/* This was added in Linux 5.15, but musl's headers don't have it yet */
+#ifndef AF_MCTP
+#define AF_MCTP 45
+#endif
+
+const char *af_to_str(int af)
+{
+  switch (af) {
+  case AF_UNSPEC:
+    return "AF_UNSPEC";
+  case AF_UNIX:
+    return "AF_UNIX";
+  case AF_INET:
+    return "AF_INET";
+  case AF_AX25:
+    return "AF_AX25";
+  case AF_IPX:
+    return "AF_IPX";
+  case AF_APPLETALK:
+    return "AF_APPLETALK";
+  case AF_NETROM:
+    return "AF_NETROM";
+  case AF_BRIDGE:
+    return "AF_BRIDGE";
+  case AF_ATMPVC:
+    return "AF_ATMPVC";
+  case AF_X25:
+    return "AF_X25";
+  case AF_INET6:
+    return "AF_INET6";
+  case AF_ROSE:
+    return "AF_ROSE";
+  case AF_DECnet:
+    return "AF_DECnet";
+  case AF_NETBEUI:
+    return "AF_NETBEUI";
+  case AF_SECURITY:
+    return "AF_SECURITY";
+  case AF_KEY:
+    return "AF_KEY";
+  case AF_NETLINK:
+    return "AF_NETLINK";
+  case AF_PACKET:
+    return "AF_PACKET";
+  case AF_ASH:
+    return "AF_ASH";
+  case AF_ECONET:
+    return "AF_ECONET";
+  case AF_ATMSVC:
+    return "AF_ATMSVC";
+  case AF_RDS:
+    return "AF_RDS";
+  case AF_SNA:
+    return "AF_SNA";
+  case AF_IRDA:
+    return "AF_IRDA";
+  case AF_PPPOX:
+    return "AF_PPPOX";
+  case AF_WANPIPE:
+    return "AF_WANPIPE";
+  case AF_LLC:
+    return "AF_LLC";
+  case AF_IB:
+    return "AF_IB";
+  case AF_MPLS:
+    return "AF_MPLS";
+  case AF_CAN:
+    return "AF_CAN";
+  case AF_TIPC:
+    return "AF_TIPC";
+  case AF_BLUETOOTH:
+    return "AF_BLUETOOTH";
+  case AF_IUCV:
+    return "AF_IUCV";
+  case AF_RXRPC:
+    return "AF_RXRPC";
+  case AF_ISDN:
+    return "AF_ISDN";
+  case AF_PHONET:
+    return "AF_PHONET";
+  case AF_IEEE802154:
+    return "AF_IEEE802154";
+  case AF_CAIF:
+    return "AF_CAIF";
+  case AF_ALG:
+    return "AF_ALG";
+  case AF_NFC:
+    return "AF_NFC";
+  case AF_VSOCK:
+    return "AF_VSOCK";
+  case AF_KCM:
+    return "AF_KCM";
+  case AF_QIPCRTR:
+    return "AF_QIPCRTR";
+  case AF_SMC:
+    return "AF_SMC";
+  case AF_XDP:
+    return "AF_XDP";
+  case AF_MCTP:
+    return "AF_MCTP";
+  default:
+    return "unknown";
+  }
+}
+
 /* Callback function for each netlink message
  * Iterates over all "struct rtmgrp" and checks whether
  * the "nlmsg_type" is their "new" or "del" type and calls

--- a/src/netlink.h
+++ b/src/netlink.h
@@ -50,6 +50,8 @@ extern struct rtmgrp __stop_rtmgrp;
 int luaopen_netlink(lua_State *L);
 int netlink_ethtool(lua_State *L);
 
+const char *af_to_str(int af);
+
 void push_string(lua_State *L, const char *which, const char *value);
 void push_integer(lua_State *L, const char *which, lua_Integer value);
 void push_bool(lua_State *L, const char *which, int value);


### PR DESCRIPTION
Sometimes it is necessary to know the family of a link notification to interpret it correctly. For example, nlmsg_type=RTM_DELLINK with ifi_family=AF_BRIDGE means that the link was removed from a bridge, not that the link itself was removed. Therefore, add this information to the Lua message.